### PR TITLE
separate server behaviour from connection handling process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.x.x](https://github.com/CrowdHailer/Ace/tree/0.4.0) - 2016-10-xx
+
+## Added
+- Connection behaviour is specified by server module.
+
 ## [0.4.0](https://github.com/CrowdHailer/Ace/tree/0.4.0) - 2016-10-06
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.x.x](https://github.com/CrowdHailer/Ace/tree/0.4.0) - 2016-10-xx
+## [0.5.0](https://github.com/CrowdHailer/Ace/tree/0.4.0) - 2016-10-07
 
 ## Added
-- Connection behaviour is specified by server module.
+- How to hande a tcp connection is specified by an application server module.
 
 ## [0.4.0](https://github.com/CrowdHailer/Ace/tree/0.4.0) - 2016-10-06
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,39 @@
 
 ## Usage
 
-#### startup
+Ace manages TCP connections by refering to a application level server specification.
+A server must implement 4 callbacks:
+
+- `init(connection, configuration)` for establishing a new connection.
+- `handle_packet(packet, state)` to handle incomming TCP packets.
+- `handle_info(message, state)` to handle application messages sent to the server.
+- `terminate` to do any cleanup when the connection is closed.
+
+#### Server
+
+```elixir
+defmodule MyServer do
+  def init(_connection, state = {:greeting, greeting}) do
+    {:send, greeting, state}
+  end
+
+  def handle_packet(inbound, state) do
+    {:send, "ECHO: #{String.strip(inbound)}\r\n", state}
+  end
+
+  def handle_info(notification, state) do
+    {:send, "#{notification}\r\n", state}
+  end
+
+  def terminate(_reason, _state) do
+    IO.puts("Socket connection closed")
+  end
+end
+```
+
+Defining my server above we can use it to start a server managed by Ace.
+
+#### Startup
 
 From the console, start mix.
 
@@ -30,7 +62,7 @@ iex -S mix
 
 In the `iex` console, start a TCP server.
 ```elixir
-{:ok, server} = Ace.TCP.start(8080)
+{:ok, server} = Ace.TCP.start(8080, {MyServer, {:greeting, "WELCOME"}})
 ```
 
 #### Connect

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
     # Running Dialyzer takes up a lot of memory and does not give useful errors if it runs out of memory.
     # http://stackoverflow.com/questions/39854839/dialyxir-mix-task-to-create-plt-exits-without-error-or-creating-table?noredirect=1#comment66998902_39854839
-    v.memory = 2048
+    v.memory = 3000
     v.cpus = 2
   end
 end

--- a/lib/ace/tcp.ex
+++ b/lib/ace/tcp.ex
@@ -1,21 +1,4 @@
 defmodule Ace.TCP do
-  defmodule DefaultServer do
-    def init(_connection, state = {:greeting, greeting}) do
-      {:send, greeting, state}
-    end
-
-    def handle_packet(inbound, state) do
-      {:send, "ECHO: #{String.strip(inbound)}\r\n", state}
-    end
-
-    def handle_info(notification, state) do
-      {:send, "#{notification}\r\n", state}
-    end
-
-    def terminate(_reason, _state) do
-      IO.puts("Socket connection closed")
-    end
-  end
   @moduledoc """
   TCP connections are handled by the `Ace.TCP` server.
 
@@ -53,7 +36,7 @@ defmodule Ace.TCP do
   @doc """
   Starts the server listening on the given port.
   """
-  def start(port, app \\ {DefaultServer, {:greeting, "WELCOME\r\n"}}) do
+  def start(port, app) do
     # Setup a socket to listen with our TCP options
     {:ok, listen_socket} = TCP.listen(port, @tcp_options)
 

--- a/lib/ace/tcp.ex
+++ b/lib/ace/tcp.ex
@@ -74,21 +74,21 @@ defmodule Ace.TCP do
     # This stops the mailbox getting flooded but also also the server to respond to non tcp messages, this was not possible `using gen_tcp.recv`.
     :ok = :inet.setopts(socket, active: :once)
     receive do
-      # For any incoming tcp packet respond by echoing the incomming message.
+      # For any incoming tcp packet call the `handle_packet` action.
       {:tcp, ^socket, message} ->
         case mod.handle_packet(message, state) do
           {:send, message, new_state} ->
             :ok = TCP.send(socket, message)
             loop(socket, {mod, new_state})
         end
-      # Send any erlang message that matches this pattern to the connected client.
+      # For any incoming erlang message the `handle_info` action.
       {:data, message} ->
         case mod.handle_info(message, state) do
           {:send, message, _state} ->
             :ok = TCP.send(socket, message)
           end
         loop(socket, app)
-      # If the socket is closed print a debug message.
+      # If the socket is closed call the `terminate` action.
       # Do not reenter handling loop.
       {:tcp_closed, ^socket} ->
         case mod.terminate(:tcp_closed, state) do

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Ace.Mixfile do
 
   def project do
     [app: :ace,
-    version: "0.4.0",
+    version: "0.5.0",
     elixir: "~> 1.0",
     build_embedded: Mix.env == :prod,
     start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Next step on the roadmap #2 having application defined behaviours.

Need to decide on terms
- **Server** The module defining response to events on the connection. e.g. `init`, `handle_packet`, `handle_info` and terminate.
- **Connection** The process using a Server module to manage an accepted socket.
- **Endpoint** What Ace.TCP provides when started with a server application