### PR TITLE
Getting started guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,0 +1,70 @@
+The aim of this guide is to get you serving content as soon as possible.
+
+### Prerequisits
+
+This guide assumes Elixir [is already installed](https://elixir-lang.org/install.html).
+
+### A new project
+
+Start a new project using mix:
+
+```
+$ mix new hello --sup
+$ cd hello
+```
+
+- The name of our project is `hello`, replace with your own.
+- The `--sup` flag is used because our project will start processes, i.e. it is not just library code.
+
+### Add Ace to project
+
+Our newly created project includes a `mix.exs` file.
+This file includes a list of dependencies, where we can add Ace.
+
+```elixir
+defp deps do
+  [
+    {:ace, "~> 0.14.6"}
+  ]
+end
+```
+
+To install all dependencies with mix run:
+
+```
+$ mix deps.get
+```
+
+### Start a Service
+
+*Note and a `service` consists of many servers, one for each client. Starting a service can be considered the same as starting the 'server'.*
+
+Our service needs to start when the application is started.
+To start a service add it to the list of children found in `lib/hello/application.ex`.
+
+```elixir
+def start(_type, _args) do
+  children = [
+    {Ace.HTTP.Service, {Hello.WWW, %{}, [port: 8443]}}
+  ]
+
+  opts = [strategy: :one_for_one, name: Hello.Supervisor]
+  Supervisor.start_link(children, opts)
+end
+```
+
+Now our application will run.
+A mix projected is started by the command:
+
+```
+$ iex -S mix
+```
+
+Visit https://localhost:8443.
+
+### Create a Homepage
+
+`Hello.WWW` is the definition of our web application.
+Let's create one that servers a single homepage
+
+> use impl


### PR DESCRIPTION
This guide should be published with version 1.0 (or at least one of the release candidate)

- [ ] Quick to start guide on README
- [x] `Ace.HTTP.Service` needs to add a childspec
- [x] `Ace.HTTP.Service` should log that it has started and url (with http(s) to visit.
- [x] `Ace.HTTP.Service` needs a nice error if module is not a `Raxx.Server`
  Either when starting a service if the module is not loaded then replace with default module,
  log warning saying using default
  This module would have to constantly check if code loaded at runtime for live reloading
  OR expand the getting started guide to define `Hello.WWW` before starting service for the first time,
  The default `Raxx.Server` implementation can then define a homepage saying please overwrite me.
  Should also log warning for each request that is handled saying shown default content.
- [ ] Default content should show module to implement, could use macro.to_string on default content.
- [x] Create first homepage, hello world
- [ ] Create post, hello to message.
- [ ] watch stream, chat app.
- [ ] `Ace.HTTP.Service` should start without setting up certificates
  a) use default certificates, running when MIX_ENV != prod
  b) provide certificate and certfile from helper functions that error in production, are explicit. and call into Ace priv
  The are not that insecure because they are not signed by any CA, so publishing to production wont compromise clients.



>Ace is designed to fit within the Elixir/erlang ecosystem.
>Services can be started one at a time or as needed