### PR TITLE
Use supervisor spec in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Add the services to be supervised in the application file `lib/my_app/applicatio
 
 ```elixir
 defmodule MyApp.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
 
   use Application
@@ -82,13 +80,10 @@ defmodule MyApp.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    # List all child processes to be supervised
     children = [
-      {MyApp, [%{greeting: "Hello"}]},
+      worker(MyApp, [%{greeting: "Hello"}]),
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: MyApp.Supervisor]
     Supervisor.start_link(children, opts)
   end


### PR DESCRIPTION
The module-based child spec is not supported.