### PR TITLE
Updating the HTTP clients

### DIFF
--- a/lib/ace/http1/client.ex
+++ b/lib/ace/http1/client.ex
@@ -1,0 +1,143 @@
+defmodule Ace.HTTP1.Client do
+  @moduledoc """
+  Build request in parts
+
+  request
+
+  Ace.HTTP1.Client.send_sync(request, host)
+  #=>{:ok, response}
+
+  {:ok, ref} send
+  cancel (ref)
+
+
+  await_response
+
+  NOTE: This module defines a `send/2` function that would clash with the `Kernel` implementation
+  """
+
+  import Kernel, except: [send: 2]
+
+
+  # Could take a third argument that is a supervisor
+  def send(request, endpoint) do
+    # `Endpoint.connect`
+    # Linking to calling process is not an issue if never errors i.e. will always close
+    # use monitor for exit normal
+    {:ok, endpoint} = GenServer.start_link(__MODULE__, {:client, endpoint})
+
+    # channel could be created with a monitor on the process
+    # channel would be called link
+    GenServer.call(endpoint, {:send, self(), [request]})
+  end
+  def send_sync(request, endpoint) do
+    # ref should definetly contain a monitor
+    {:ok, ref} = send(request, endpoint)
+    {:ok, head} = await_response(ref)
+  end
+  # Getting a channel should block until one is available.
+  # But pipelining in HTTP/1 is just a bit weird
+
+  def await_response(ref) do
+    {:ok, head} = await_head(ref)
+    # NOTE matches on no trailers
+    {:ok, {body, []}} = if head.body do
+      await_tail(ref)
+    else
+      {:ok, {"", []}}
+    end
+    {:ok, %{head | body: body}}
+  end
+  defp await_head(ref) do
+    receive do
+      {^ref, head = %Raxx.Response{}} ->
+        {:ok, head}
+    end
+  end
+  defp await_tail(ref, buffer \\ "") do
+    receive do
+      {^ref, %Raxx.Data{data: data}} ->
+        await_tail(ref, buffer <> data)
+      {^ref, %Raxx.Tail{headers: trailers}} ->
+        {:ok, {buffer, trailers}}
+    end
+  end
+
+  @enforce_keys [
+    # Link to the TCP or SSL connection
+    :socket,
+
+    # reference to the
+    :channel,
+
+    :receive_state
+  ]
+  defstruct @enforce_keys
+
+  def init({:client, endpoint}) do
+    {:ok, socket} = Ace.Socket.connect(endpoint)
+
+    state = %__MODULE__{
+      socket: socket,
+      channel: nil,
+      receive_state: Ace.HTTP1.Parser.new(max_line_length: 2048)
+    }
+    {:ok, state}
+  end
+
+  def handle_call({:send, worker, parts}, from, state = %{channel: nil}) do
+    # NOTE change 1 to latest id for streaming.
+    channel_number = 1
+
+    channel_ref = {:http1, self(), channel_number}
+
+    monitor = Process.monitor(worker)
+    channel = {worker, monitor, channel_number}
+    new_state = %{state | channel: channel}
+
+    {packets, newer_state} = prepare(parts, new_state)
+    IO.inspect(packets)
+
+    Ace.Socket.send(state.socket, packets)
+    {:reply, {:ok, channel_ref}, newer_state}
+  end
+
+
+  def handle_info({t, s, packet}, state = %{socket: {t, s}}) do
+    IO.inspect(packet)
+    case Ace.HTTP1.Parser.parse(packet, state.receive_state) do
+      {:ok, {parts, receive_state}} ->
+        {worker, channel_ref} = channel_ref(state.channel)
+        Enum.each(parts, &Kernel.send(worker, {channel_ref, &1}))
+        {:noreply, %{state | receive_state: receive_state}}
+    end
+  end
+  def handle_info({transport, _socket}, state)
+      when transport in [:tcp_closed, :ssl_closed] do
+    {:stop, :normal, state}
+  end
+
+  defp prepare(parts, state) do
+    Enum.reduce(parts, {[], state}, fn
+      (request = %Raxx.Request{body: false}, {queue, state}) ->
+        "//" <> host = "#{%URI{authority: request.authority}}"
+        headers = [{"host", host} | request.headers]
+
+        start_line = [Atom.to_string(request.method), " ", raxx_to_path(request), " HTTP/1.1"]
+        header_lines = Enum.map(headers, fn({k, v}) -> [k, ": ", v] end)
+        request = Enum.map([start_line] ++ header_lines ++ [""], fn(line) -> [line, "\r\n"] end)
+        {queue ++ request, state}
+    end)
+  end
+
+  defp raxx_to_path(%{path: segments, query: query}) do
+    path = "/" <> Enum.join(segments, "/")
+    query_string = URI.encode_query(query || %{})
+    query = if query_string == "", do: "", else: "?" <> query_string
+    [path, query]
+  end
+
+  defp channel_ref({worker, _monitor, id}, endpoint \\ self()) do
+    {worker, {:http1, endpoint, id}}
+  end
+end

--- a/lib/ace/http1/client.ex
+++ b/lib/ace/http1/client.ex
@@ -1,25 +1,74 @@
 defmodule Ace.HTTP1.Client do
   @moduledoc """
-  Build request in parts
+  Simple API client that makes streaming easy.
 
-  request
+  This client will send any `Raxx.Request` struct to a server.
+  Raxx provedes basic tools for manipulating requests.
 
-  Ace.HTTP1.Client.send_sync(request, host)
-  #=>{:ok, response}
+      request = Raxx.request(:POST, "/headers")
+      |> Raxx.set_header("accept", "application/json")
+      |> Raxx.set_body("Hello, httpbin")
 
-  {:ok, ref} send
-  cancel (ref)
+  ## Synchronous dispatch
 
+  Send a request and wait for the complete response.
+  The response will be a complete `Raxx.Response`.
 
-  await_response
+      {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+      # => {:ok, %Raxx.Response{...
 
-  NOTE: This module defines a `send/2` function that would clash with the `Kernel` implementation
+      response.status
+      # => 200
+
+  ## Asynchronous responses
+
+  `send_sync/2` is a wrapper around the underlying async api.
+  To send requests asynchronously use `send/2`
+
+      {:ok, channel_ref} = Ace.HTTP1.Client.send(request, "http://httpbin.org")
+
+      receive do: {^channel_ref, %Raxx.Response{}} -> :ok
+      receive do: {^channel_ref, %Raxx.Data{}} -> :ok
+      receive do: {^channel_ref, %Raxx.Tail{}} -> :ok
+
+  - *A response with no body will return only a `Raxx.Response`*
+  - *A response with a body can return any number of `Raxx.Data` parts*
+
+  ## Streamed data
+
+  A request can have a body value of true indicating that the body will be sent later.
+  The channel_ref returned when sending to an endpoint can be used to send follow up data.
+
+      request = Raxx.request(:POST, "/headers")
+      |> Raxx.set_header("accept", "application/json")
+      |> Raxx.set_header("content-length", "13")
+      |> Raxx.set_body(true)
+
+      {:ok, channel_ref} = Ace.HTTP1.Client.send(request, "http://httpbin.org")
+
+      data = Raxx.data("Hello, httpbin")
+      {:ok, channel_ref} = Ace.HTTP1.Client.send(data, "http://httpbin.org")
+
+      receive do: {^channel_ref, %Raxx.Response{}} -> :ok
+      receive do: {^channel_ref, %Raxx.Data{}} -> :ok
+      receive do: {^channel_ref, %Raxx.Tail{}} -> :ok
+
+  NOTE: This module defines a `send/2` function clashes with `Kernel.send/2` if imported
   """
 
   import Kernel, except: [send: 2]
+  require OK
 
-
+  @type channel_ref :: {:http1, pid(), integer}
   # Could take a third argument that is a supervisor
+
+  @doc """
+  Send a request, or part of, to a remote endpoint.
+  """
+  @spec send(Raxx.Response.t, String.t) :: {:ok, channel_ref} | {:error, any()}
+  def send(part, channel_ref = {:http1, endpoint, _}) do
+    GenServer.call(endpoint, {:send, channel_ref, [part]})
+  end
   def send(request, endpoint) do
     # `Endpoint.connect`
     # Linking to calling process is not an issue if never errors i.e. will always close
@@ -30,28 +79,46 @@ defmodule Ace.HTTP1.Client do
     # channel would be called link
     GenServer.call(endpoint, {:send, self(), [request]})
   end
+  @doc """
+  Send a request to a server and await the full response.
+
+  The endpoint can be an open connection or host.
+  see `send/2` for details
+  """
   def send_sync(request, endpoint) do
     # ref should definetly contain a monitor
-    {:ok, ref} = send(request, endpoint)
-    {:ok, head} = await_response(ref)
+    OK.for do
+      _ <- if Raxx.complete?(request), do: {:ok, nil}, else: {:error, :incomplete_request}
+      ref <- send(request, endpoint)
+      response <- await_response(ref)
+    after
+      response
+    end
   end
   # Getting a channel should block until one is available.
   # But pipelining in HTTP/1 is just a bit weird
 
   def await_response(ref) do
-    {:ok, head} = await_head(ref)
-    # NOTE matches on no trailers
-    {:ok, {body, []}} = if head.body do
-      await_tail(ref)
-    else
-      {:ok, {"", []}}
+    OK.for do
+      head <- await_head(ref)
+      # NOTE matches on no trailers
+      {body, []} <- if head.body do
+        await_tail(ref)
+      else
+        {:ok, {"", []}}
+      end
+    after
+      %{head | body: body}
     end
-    {:ok, %{head | body: body}}
   end
   defp await_head(ref) do
+    timeout = 5_000
     receive do
       {^ref, head = %Raxx.Response{}} ->
         {:ok, head}
+    after
+      timeout ->
+        {:error, {:timeout, timeout}}
     end
   end
   defp await_tail(ref, buffer \\ "") do
@@ -70,19 +137,26 @@ defmodule Ace.HTTP1.Client do
     # reference to the
     :channel,
 
-    :receive_state
+    :receive_state,
+
+    :authority,
   ]
   defstruct @enforce_keys
 
   def init({:client, endpoint}) do
-    {:ok, socket} = Ace.Socket.connect(endpoint)
-
-    state = %__MODULE__{
-      socket: socket,
-      channel: nil,
-      receive_state: Ace.HTTP1.Parser.new(max_line_length: 2048)
-    }
-    {:ok, state}
+    case Ace.Socket.connect(endpoint) do
+      {:ok, socket} ->
+        %{authority: authority} = URI.parse(endpoint)
+        state = %__MODULE__{
+          socket: socket,
+          channel: nil,
+          receive_state: Ace.HTTP1.Parser.new(max_line_length: 2048),
+          authority: authority
+        }
+        {:ok, state}
+      {:error, reason} ->
+        :ignore
+    end
   end
 
   def handle_call({:send, worker, parts}, from, state = %{channel: nil}) do
@@ -100,6 +174,13 @@ defmodule Ace.HTTP1.Client do
 
     Ace.Socket.send(state.socket, packets)
     {:reply, {:ok, channel_ref}, newer_state}
+  end
+  def handle_call({:send, channel_ref, parts}, from, state) do
+    {packets, new_state} = prepare(parts, state)
+    IO.inspect(packets)
+
+    Ace.Socket.send(state.socket, packets)
+    {:reply, {:ok, channel_ref}, new_state}
   end
 
 
@@ -120,14 +201,42 @@ defmodule Ace.HTTP1.Client do
   defp prepare(parts, state) do
     Enum.reduce(parts, {[], state}, fn
       (request = %Raxx.Request{body: false}, {queue, state}) ->
-        "//" <> host = "#{%URI{authority: request.authority}}"
+        host = request.authority || state.authority
         headers = [{"host", host} | request.headers]
 
         start_line = [Atom.to_string(request.method), " ", raxx_to_path(request), " HTTP/1.1"]
-        header_lines = Enum.map(headers, fn({k, v}) -> [k, ": ", v] end)
-        request = Enum.map([start_line] ++ header_lines ++ [""], fn(line) -> [line, "\r\n"] end)
+        request = Enum.map([start_line] ++ raxx_header_lines(headers) ++ [""], fn(line) -> [line, "\r\n"] end)
         {queue ++ request, state}
+      (request = %Raxx.Request{body: true}, {queue, state}) ->
+        host = request.authority || state.authority
+        headers = [{"host", host} | request.headers]
+
+        header_lines = Enum.map(headers, fn({k, v}) -> [k, ": ", v] end)
+        request = Enum.map([raxx_start_line(request)] ++ header_lines ++ [""], fn(line) -> [line, "\r\n"] end)
+        {queue ++ request, state}
+      (request = %Raxx.Request{body: body}, {queue, state}) when is_binary(body) ->
+        content_length = :erlang.iolist_size(body)
+        host = request.authority || state.authority
+        headers = [{"host", host}, {"content-length", "#{content_length}"} | request.headers]
+        header_lines = Enum.map(headers, fn({k, v}) -> [k, ": ", v] end)
+        request = Enum.map([raxx_start_line(request)] ++ header_lines ++ [""], fn(line) -> [line, "\r\n"] end)
+
+        {queue ++ request ++ [body], state}
+      (request = %Raxx.Data{data: data}, {queue, state}) ->
+        {queue ++ [data], state}
     end)
+  end
+
+  defp raxx_header(%{headers: headers}, header, default \\ :undefined) do
+
+  end
+
+  defp raxx_start_line(request) do
+    [Atom.to_string(request.method), " ", raxx_to_path(request), " HTTP/1.1"]
+  end
+
+  defp raxx_header_lines(headers) do
+    Enum.map(headers, fn({k, v}) -> [k, ": ", v] end)
   end
 
   defp raxx_to_path(%{path: segments, query: query}) do

--- a/lib/ace/socket.ex
+++ b/lib/ace/socket.ex
@@ -44,6 +44,18 @@ defmodule Ace.Socket do
     end
   end
 
+  def connect(endpoint = "http://" <> _) do
+    uri = URI.parse(endpoint)
+    "http" = uri.scheme
+    port = uri.port || 80
+    connect(:http, :erlang.binary_to_list(uri.host), port)
+  end
+
+  defp connect(:http, host, port) do
+    {:ok, socket} = :gen_tcp.connect(host, port, [:binary, {:active, true}])
+    {:ok, {:tcp, socket}}
+  end
+
   def port({:tcp, socket}) do
     :inet.port(socket)
   end

--- a/lib/ace/socket.ex
+++ b/lib/ace/socket.ex
@@ -15,6 +15,8 @@ defmodule Ace.Socket do
   """
   @type listen_socket :: {:ssl, :"ssl.ListenSocket"} | {:tcp, :inet.socket()}
 
+  require OK
+
   def accept({:tcp, listen_socket}) do
     case :gen_tcp.accept(listen_socket) do
       {:ok, socket} ->
@@ -52,8 +54,11 @@ defmodule Ace.Socket do
   end
 
   defp connect(:http, host, port) do
-    {:ok, socket} = :gen_tcp.connect(host, port, [:binary, {:active, true}])
-    {:ok, {:tcp, socket}}
+    OK.for do
+      socket <- :gen_tcp.connect(host, port, [:binary, {:active, true}])
+    after
+      {:tcp, socket}
+    end
   end
 
   def port({:tcp, socket}) do

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule Ace.Mixfile do
     [
       {:hpack, "~> 0.2.3", hex: :hpack_erl},
       {:raxx, "~> 0.14.5"},
+      {:ok, "~> 1.9"},
       {:dialyxir, "~> 0.5.0", only: :dev},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -4,5 +4,6 @@
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
+  "ok": {:hex, :ok, "1.9.4", "fc8ff2193160c7a56bf2cf446077ff6a7bea34463b6c1958b101404a1b5a7fd3", [], [], "hexpm"},
   "raxx": {:hex, :raxx, "0.14.5", "d7187d05e41c9385b84ffb9e229d5caf1275ee1786066d23a5fbbc66171489b7", [:mix], [], "hexpm"},
 }

--- a/test/ace/http1/client_test.exs
+++ b/test/ace/http1/client_test.exs
@@ -1,0 +1,59 @@
+defmodule Ace.HTTP1.ClientTest do
+  use ExUnit.Case, async: true
+
+  # REQUEST
+
+  test "sends the correct method" do
+    request = Raxx.request(:GET, "/anything")
+    request = %{request | authority: "httpbin.org"}
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+
+    assert String.contains?(response.body, "\"method\": \"GET\"")
+
+    request = Raxx.request(:DELETE, "/anything")
+    request = %{request | authority: "httpbin.org"}
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+
+    assert String.contains?(response.body, "\"method\": \"DELETE\"")
+  end
+
+  test "sends correct host header from request" do
+    request = Raxx.request(:GET, "/headers")
+    request = %{request | authority: "httpbin.org"}
+
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+
+    assert String.contains?(response.body, "\"Host\": \"httpbin.org\"")
+  end
+
+  # RESPONSE
+
+  test "decodes correct status" do
+    request = Raxx.request(:GET, "/status/503")
+    request = %{request | authority: "httpbin.org"}
+
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+    assert response.status == 503
+  end
+
+  test "decodes response headers" do
+    request = Raxx.request(:GET, "/response-headers?lowercase=foo&UPPERCASE=BAR")
+    request = %{request | authority: "httpbin.org"}
+
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+    assert "foo" == :proplists.get_value("lowercase", response.headers)
+    assert "BAR" == :proplists.get_value("uppercase", response.headers)
+  end
+
+  # TODO use delay to test timeout
+  test "decodes response headers auth" do
+    # request = Raxx.request(:GET, "/drip?duration=5&code=200&numbytes=5")
+    request = Raxx.request(:GET, "/stream/5")
+    request = %{request | authority: "httpbin.org"}
+
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+    |> IO.inspect()
+    assert "foo" == :proplists.get_value("lowercase", response.headers)
+    assert "BAR" == :proplists.get_value("uppercase", response.headers)
+  end
+end

--- a/test/ace/http1/client_test.exs
+++ b/test/ace/http1/client_test.exs
@@ -5,16 +5,22 @@ defmodule Ace.HTTP1.ClientTest do
 
   test "sends the correct method" do
     request = Raxx.request(:GET, "/anything")
-    request = %{request | authority: "httpbin.org"}
     {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
 
     assert String.contains?(response.body, "\"method\": \"GET\"")
 
     request = Raxx.request(:DELETE, "/anything")
-    request = %{request | authority: "httpbin.org"}
     {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
 
     assert String.contains?(response.body, "\"method\": \"DELETE\"")
+  end
+
+  test "adds host information from connection if not given" do
+    request = Raxx.request(:GET, "/headers")
+
+    {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
+
+    assert String.contains?(response.body, "\"Host\": \"httpbin.org\"")
   end
 
   test "sends correct host header from request" do
@@ -26,11 +32,46 @@ defmodule Ace.HTTP1.ClientTest do
     assert String.contains?(response.body, "\"Host\": \"httpbin.org\"")
   end
 
+  test "can send data with request" do
+    request = Raxx.request(:POST, "/post")
+    |> Raxx.set_body("Hello, World!")
+
+    {:ok, ref} = Ace.HTTP1.Client.send(request, "http://httpbin.org")
+    assert_receive {^ref, %Raxx.Response{}}, 1_000
+    assert_receive {^ref, %Raxx.Data{}}, 1_000
+    assert_receive {^ref, %Raxx.Tail{}}, 1_000
+  end
+
+  test "can send data after request" do
+    request = Raxx.request(:POST, "/post")
+    |> Raxx.set_header("content-length", "13")
+
+    {:ok, ref} = Ace.HTTP1.Client.send(request, "http://httpbin.org")
+
+    data = Raxx.data("Hello, World!")
+    {:ok, ref} = Ace.HTTP1.Client.send(data, ref)
+    assert_receive {^ref, %Raxx.Response{}}, 1_000
+    assert_receive {^ref, %Raxx.Data{}}, 1_000
+    assert_receive {^ref, %Raxx.Tail{}}, 1_000
+  end
+
+
+
+  test "can stream data with content_length" do
+
+  end
+
+  test "returns error if unable to connect to endpoint" do
+    request = Raxx.request(:GET, "/")
+
+    # TODO we need to somehow forward error
+    :ignore = Ace.HTTP1.Client.send_sync(request, "http://fooo.dummy")
+  end
+
   # RESPONSE
 
   test "decodes correct status" do
     request = Raxx.request(:GET, "/status/503")
-    request = %{request | authority: "httpbin.org"}
 
     {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
     assert response.status == 503
@@ -38,22 +79,32 @@ defmodule Ace.HTTP1.ClientTest do
 
   test "decodes response headers" do
     request = Raxx.request(:GET, "/response-headers?lowercase=foo&UPPERCASE=BAR")
-    request = %{request | authority: "httpbin.org"}
 
     {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
     assert "foo" == :proplists.get_value("lowercase", response.headers)
     assert "BAR" == :proplists.get_value("uppercase", response.headers)
   end
 
-  # TODO use delay to test timeout
-  test "decodes response headers auth" do
-    # request = Raxx.request(:GET, "/drip?duration=5&code=200&numbytes=5")
-    request = Raxx.request(:GET, "/stream/5")
-    request = %{request | authority: "httpbin.org"}
+  test "body will be added to response" do
+    request = Raxx.request(:GET, "/drip?numbytes=5&duration=1")
 
     {:ok, response} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
-    |> IO.inspect()
-    assert "foo" == :proplists.get_value("lowercase", response.headers)
-    assert "BAR" == :proplists.get_value("uppercase", response.headers)
+    assert "*****" = response.body
+  end
+
+  test "body message will be received for every streamed chunk" do
+    request = Raxx.request(:GET, "/stream/2")
+
+    {:ok, ref} = Ace.HTTP1.Client.send(request, "http://httpbin.org")
+    assert_receive {^ref, %Raxx.Response{status: 200}}
+    assert_receive {^ref, %Raxx.Data{}}
+    assert_receive {^ref, %Raxx.Data{data: _}}
+    assert_receive {^ref, %Raxx.Tail{}}
+  end
+
+  test "will timeout after delay" do
+    request = Raxx.request(:GET, "/delay/10")
+
+    assert {:error, {:timeout, 5_000}} = Ace.HTTP1.Client.send_sync(request, "http://httpbin.org")
   end
 end


### PR DESCRIPTION
Ace is both client and server for HTTP/2. as it now has a server for HTTP/1 it should also have a client.

There are several reasons I think that this would be valuable. 

1. When developing Raxx based server applications testing can be achieved using the same Raxx structs.
2. When developing Raxx based clients dummy servers can be set up allowing testing of these to also use the same Raxx structs.
3. Raxx being a data representation of HTTP messages makes it very easy to compose properties of requests.
  ```elixir
  request(:GET, "myapp.test/foo/bar")
  |> accept_json()
  |> set_basic_auth(username, password)
  ``` 
------

HTTP/2 requires a clearer separation of connection from request, there is no point using HTTP/2 to send a single request to a server. As the position of Ace is to have HTTP/1 support just be a fallback when HTTP/2 is missing then we should use the same semantics for HTTP/1&2

```elixir
{:ok, client} = Ace.Client.start_link
{:ok, channel} = Ace.Client.send(client, request)
```

Need a cancel_channel as well as connection.stop

connect only after init. error returnd for first send

### Notes
- We async send we cannot auto create the connection and successfully close the monitor, *unless monitors can be demonitored from a different process?*
  The sync send could support a string argument for the send location.
- In a client there is no unrecoverable error. A new domain and service could always come up in time. I think the endpoint should keep trying to connect and the calls to send request fail. Choices for reconnect
  - After certain time
  - On next request, (favour this one makes it easier to returnerror)
  - HTTP/1 without pipelining can still create an interface for streaming. Need to investiagte connection pooling
 