### PR TITLE
Add remote-client IP & port info

### DIFF
--- a/lib/ace/http/server.ex
+++ b/lib/ace/http/server.ex
@@ -69,7 +69,7 @@ defmodule Ace.HTTP.Server do
               receive_state: Ace.HTTP1.Parser.new(max_line_length: 2048)
             }
             
-            Logger.debug(client_info(socket))
+            Logger.debug(Ace.Socket.client_info(socket))
 
             GenServer.reply(from, {:ok, self()})
             :gen_server.enter_loop(Ace.HTTP1.Endpoint, [], state)
@@ -111,7 +111,7 @@ defmodule Ace.HTTP.Server do
 
             :ok = Ace.Socket.set_active(socket)
             
-            Logger.debug(client_info(socket))
+            Logger.debug(Ace.Socket.client_info(socket))
 
             :gen_server.enter_loop(Ace.HTTP2.Connection, [], {:pending, initial_state})
         end
@@ -119,19 +119,5 @@ defmodule Ace.HTTP.Server do
       {:error, reason} ->
         {:stop, :normal, {:error, reason}, state}
     end
-  end
-  
-  # defp client_info(soc) do
-  #   "soc:\n#{inspect(soc)}\n"
-  # end
-
-  defp client_info({:ssl, socket}) do
-    {:ok, {{a, b, c, d}, port}} = :ssl.peername(socket)
-    "[#{inspect(self())}] <<< #{a}.#{b}.#{c}.#{d}:#{port}"
-  end
-
-  defp client_info({:tcp, socket}) do
-    {:ok, {{a, b, c, d}, port}} = :inet.peername(socket)
-    "[#{inspect(self())}] <<< #{a}.#{b}.#{c}.#{d}:#{port}"
   end
 end

--- a/lib/ace/socket.ex
+++ b/lib/ace/socket.ex
@@ -85,4 +85,18 @@ defmodule Ace.Socket do
   def send({:ssl, socket}, message) do
     :ssl.send(socket, message)
   end
+  
+  # defp client_info(soc) do
+  #   "soc:\n#{inspect(soc)}\n"
+  # end
+
+  def client_info({:ssl, socket}) do
+    {:ok, {{a, b, c, d}, port}} = :ssl.peername(socket)
+    "[#{inspect(self())}] <<< #{a}.#{b}.#{c}.#{d}:#{port}"
+  end
+
+  def client_info({:tcp, socket}) do
+    {:ok, {{a, b, c, d}, port}} = :inet.peername(socket)
+    "[#{inspect(self())}] <<< #{a}.#{b}.#{c}.#{d}:#{port}"
+  end
 end


### PR DESCRIPTION
This logger.debug prints remote-client IP & port info.

It adds this sort of info:
`16:53:31.243 [debug] [#PID<0.229.0>] <<< 149.154.167.205:54926`