### PR TITLE
Return unparsed path and query

### DIFF
--- a/lib/ace/http1/parser.ex
+++ b/lib/ace/http1/parser.ex
@@ -219,12 +219,10 @@ defmodule Ace.HTTP1.Parser do
           path_string
       end
 
-    %{path: path, query: query_string} = URI.parse(path_string)
+    %{path: path, query: query} = URI.parse(path_string)
     # DEBT in case of path '//' then parsing returns path of nil.
     # e.g. localhost:8080//
-    path = path || "/"
-    {:ok, query} = URI2.Query.decode(query_string || "")
-    path = Raxx.split_path(path)
+    path = path || ""
 
     # NOTE scheme is ignored from message.
     # It should therefore not be part of request but part of connection. same as client ip etc

--- a/lib/ace/http2.ex
+++ b/lib/ace/http2.ex
@@ -168,16 +168,14 @@ defmodule Ace.HTTP2 do
       case read_headers(headers) do
         {:ok, headers} ->
           uri = URI.parse(path)
-          {:ok, query} = URI2.Query.decode(uri.query || "")
-          segments = Raxx.split_path(uri.path)
 
           request = %Raxx.Request{
             scheme: scheme,
             authority: authority,
             method: method,
             mount: [],
-            path: segments,
-            query: query,
+            path: uri.path || "",
+            query: uri.query || "",
             headers: headers,
             body: false
           }

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [], [], "hexpm"},
+  "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
   "raxx": {:hex, :raxx, "0.14.14", "b31c259ec4bdfe72a654a6e52f0e589e3a7c25faa33cf203e686e91563d6522c", [:mix], [{:cookie, "~> 0.1.0", [hex: :cookie, repo: "hexpm", optional: false]}, {:uuid, "~> 1.1", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},

--- a/test/ace/http1/server_test.exs
+++ b/test/ace/http1/server_test.exs
@@ -141,7 +141,7 @@ defmodule Ace.HTTP1.ServerTest do
 
   test "can connect with alpn preferences", %{port: port} do
     http1_request = """
-    GET /foo/bar?var=1 HTTP/1.1
+    GET /foo/bar/?var=1 HTTP/1.1
     host: example.com:1234
     x-test: Value
 
@@ -167,8 +167,8 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.authority == "example.com:1234"
     assert request.method == :GET
     assert request.mount == []
-    assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.path == "/foo/bar/"
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -218,8 +218,8 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.authority == "example.com:1234"
     assert request.method == :GET
     assert request.mount == []
-    assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.path == "/foo/bar"
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -242,8 +242,8 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.authority == "example.com:1234"
     assert request.method == :GET
     assert request.mount == []
-    assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.path == "/foo/bar"
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -270,8 +270,8 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.authority == "example.com:1234"
     assert request.method == :GET
     assert request.mount == []
-    assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.path == "/foo/bar"
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -299,8 +299,8 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.authority == "example.com:1234"
     assert request.method == :GET
     assert request.mount == []
-    assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.path == "/foo/bar"
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end

--- a/test/ace/http2/client_test.exs
+++ b/test/ace/http2/client_test.exs
@@ -34,6 +34,7 @@ defmodule Ace.HTTP2.ClientTest do
     :ok = Ace.HTTP2.send(stream, request)
     data = Raxx.data("foo")
     :ok = Ace.HTTP2.send(stream, data)
+    IO.puts("STREAM*** " <> inspect(stream))
     assert_receive {^stream, response = %Response{}}, 1000
     assert 200 == response.status
     assert true == response.body

--- a/test/ace/http2_test.exs
+++ b/test/ace/http2_test.exs
@@ -51,8 +51,8 @@ defmodule Ace.HTTP2Test do
     assert received.authority == "example.com:1234"
     assert received.method == :GET
     assert received.mount == []
-    assert received.path == ["foo", "bar"]
-    assert received.query == %{"var" => "1"}
+    assert received.path == "/foo/bar"
+    assert received.query == "var=1"
     assert received.headers == request.headers
     assert received.body == false
   end
@@ -70,7 +70,7 @@ defmodule Ace.HTTP2Test do
 
     assert_receive {:"$gen_call", from, {:headers, received, state}}, 1000
     GenServer.reply(from, {[], state})
-    assert received.path == request.path
+    assert received.path == "/"
 
     data = Raxx.data("Hello, World!")
     :ok = Ace.HTTP2.send(client_stream, data)
@@ -202,7 +202,7 @@ defmodule Ace.HTTP2Test do
 
     assert_receive {
                      ^client_stream,
-                     {:promise, {client_promised_stream, %Request{path: ["favicon"]}}}
+                     {:promise, {client_promised_stream, %Request{path: "/favicon"}}}
                    },
                    1000
 


### PR DESCRIPTION
Defers parsing of the URI's path components at the server. A future change to Raxx will add parsing of these components as middleware.