### PR TITLE
update raxx version to use string queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## master
 
+### Changed
+
+- Use `raxx 0.15` which has does not expect query strings to be parsed.  
+
 ## [0.15.11](https://github.com/CrowdHailer/Ace/tree/0.15.11) - 2018-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## master
+## [0.16.0](https://github.com/CrowdHailer/Ace/tree/0.16.0) - 2018-04-18
 
 ### Changed
 

--- a/lib/ace/http1/parser.ex
+++ b/lib/ace/http1/parser.ex
@@ -219,27 +219,12 @@ defmodule Ace.HTTP1.Parser do
           path_string
       end
 
-    %{path: path, query: query_string} = URI.parse(path_string)
-    # DEBT in case of path '//' then parsing returns path of nil.
-    # e.g. localhost:8080//
-    path = path || "/"
-    {:ok, query} = URI2.Query.decode(query_string || "")
-    path = Raxx.split_path(path)
-
     # NOTE scheme is ignored from message.
     # It should therefore not be part of request but part of connection. same as client ip etc
     # However scheme is a required header in HTTP/2
     # Q? how often is a host header sent with http in place
     # %{scheme: scheme} = URI.parse(host)
 
-    %Raxx.Request{
-      scheme: nil,
-      authority: host,
-      method: method,
-      path: path,
-      query: query,
-      headers: [],
-      body: false
-    }
+    %{Raxx.request(method, path_string) | authority: host}
   end
 end

--- a/lib/ace/http2.ex
+++ b/lib/ace/http2.ex
@@ -46,12 +46,12 @@ defmodule Ace.HTTP2 do
     # TODO consider default values for required scheme and authority
     # DEBT nested queries
     query_string =
-      case URI.encode_query(request.query || %{}) do
-        "" ->
+      case request.query do
+        nil ->
           ""
 
-        encoded ->
-          "?" <> encoded
+        query ->
+          "?" <> query
       end
 
     path = "/" <> Enum.join(request.path, "/") <> query_string
@@ -167,19 +167,10 @@ defmodule Ace.HTTP2 do
     else
       case read_headers(headers) do
         {:ok, headers} ->
-          uri = URI.parse(path)
-          {:ok, query} = URI2.Query.decode(uri.query || "")
-          segments = Raxx.split_path(uri.path)
 
-          request = %Raxx.Request{
-            scheme: scheme,
-            authority: authority,
-            method: method,
-            mount: [],
-            path: segments,
-            query: query,
-            headers: headers,
-            body: false
+          request = %{Raxx.request(method, path) | scheme: scheme,
+          authority: authority,
+          headers: headers
           }
 
           {:ok, request}

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule Ace.Mixfile do
   defp deps do
     [
       {:hpack, "~> 0.2.3", hex: :hpack_erl},
-      {:raxx, "~> 0.14.5"},
+      # {:raxx, "~> 0.14.5"},
+      {:raxx, github: "crowdhailer/raxx", branch: "string-queries"},
       {:dialyxir, "~> 0.5.0", only: :dev},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ace.Mixfile do
   def project do
     [
       app: :ace,
-      version: "0.15.11",
+      version: "0.16.0",
       elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -30,8 +30,7 @@ defmodule Ace.Mixfile do
   defp deps do
     [
       {:hpack, "~> 0.2.3", hex: :hpack_erl},
-      # {:raxx, "~> 0.14.5"},
-      {:raxx, github: "crowdhailer/raxx", branch: "string-queries"},
+      {:raxx, "~> 0.15.0"},
       {:dialyxir, "~> 0.5.0", only: :dev},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,6 @@
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
-  "raxx": {:hex, :raxx, "0.14.14", "b31c259ec4bdfe72a654a6e52f0e589e3a7c25faa33cf203e686e91563d6522c", [:mix], [{:cookie, "~> 0.1.0", [hex: :cookie, repo: "hexpm", optional: false]}, {:uuid, "~> 1.1", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
+  "raxx": {:git, "https://github.com/crowdhailer/raxx.git", "1f30217bb56ab5e9f8c15c223a01be794351b723", [branch: "string-queries"]},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
   "cookie": {:hex, :cookie, "0.1.0", "4321c09d47db89c095cdee82afa44a6ccabf2755f2257d07a617d89f9d52715e", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [], [], "hexpm"},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
-  "raxx": {:git, "https://github.com/crowdhailer/raxx.git", "1f30217bb56ab5e9f8c15c223a01be794351b723", [branch: "string-queries"]},
+  "raxx": {:hex, :raxx, "0.15.0", "b0dacd17b4295c11b534b1f4916eb34578b5d2bc37aaff6f91a4fb644a668d86", [:mix], [{:cookie, "~> 0.1.0", [hex: :cookie, repo: "hexpm", optional: false]}, {:uuid, "~> 1.1", [hex: :uuid, repo: "hexpm", optional: false]}], "hexpm"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
 }

--- a/test/ace/http1/server_test.exs
+++ b/test/ace/http1/server_test.exs
@@ -168,7 +168,7 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.method == :GET
     assert request.mount == []
     assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -219,7 +219,7 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.method == :GET
     assert request.mount == []
     assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -243,7 +243,7 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.method == :GET
     assert request.mount == []
     assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -271,7 +271,7 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.method == :GET
     assert request.mount == []
     assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end
@@ -300,7 +300,7 @@ defmodule Ace.HTTP1.ServerTest do
     assert request.method == :GET
     assert request.mount == []
     assert request.path == ["foo", "bar"]
-    assert request.query == %{"var" => "1"}
+    assert request.query == "var=1"
     assert request.headers == [{"x-test", "Value"}]
     assert request.body == false
   end

--- a/test/ace/http2_test.exs
+++ b/test/ace/http2_test.exs
@@ -52,7 +52,7 @@ defmodule Ace.HTTP2Test do
     assert received.method == :GET
     assert received.mount == []
     assert received.path == ["foo", "bar"]
-    assert received.query == %{"var" => "1"}
+    assert received.query == "var=1"
     assert received.headers == request.headers
     assert received.body == false
   end


### PR DESCRIPTION
Handles #93 

NOTE: This should not be merged until the raxx dependency is updated to one on hex
