### PR TITLE
Add a reference to Raxx.Kit in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 - [Documentation available on hexdoc](https://hexdocs.pm/ace)
 - [Discuss on slack](https://elixir-lang.slack.com/messages/C56H3TBH8/)
 
+See [Raxx.Kit](https://github.com/CrowdHailer/raxx_kit) for a project generator that helps you set up 
+a web project based on [Raxx](https://github.com/CrowdHailer/raxx)/[Ace](https://github.com/CrowdHailer/Ace).
+
 ## Get started
 
 #### Hello, World!


### PR DESCRIPTION
While the readme explains the building blocks of using Ace, it might still feel like setting up a working project with Ace is a hassle, especially if you just want to try it out. Linking to Raxx.Kit at the beginning of the readme might remove some if this friction and make the onboarding seem more streamlined.

Also, in my personal opinion, Raxx.Kit is really well thought out and showcases Raxx/Ace from a good side. I found myself using bits of it even though I had my own "standard" way of setting up new projects.

Also, I think most people stumbling upon Raxx/Ace will be starting up from one of these two repositories, having Raxx.Kit more discoverable would make it look like the more coherent system it actually is.

I'd like to put a similar/same change in Raxx's readme, I'd just like to get this merged in first.