### PR TITLE
Fix incorrect warning for using Raxx.SimpleServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next
+
+### Fixed
+
+- Fix incorrectly displayed warning from `use Raxx.SimpleServer`.
+
 ## [0.18.1](https://github.com/CrowdHailer/Ace/tree/0.18.1) - 2018-11-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a web project based on [Raxx](https://github.com/CrowdHailer/raxx)/[Ace](https:/
 #### Hello, World!
 ```elixir
 defmodule MyApp do
-  use Ace.HTTP.Service, [port: 8080, cleartext: true]
+  use Ace.HTTP.Service, port: 8080, cleartext: true
   use Raxx.SimpleServer
 
   @impl Raxx.SimpleServer
@@ -38,7 +38,7 @@ end
 ```elixir
 config = %{greeting: "Hello"}
 
-MyApp.start_link(config, [port: 1234])
+MyApp.start_link(config, port: 1234)
 ```
 
 *Here the default port value has been overridden at startup*

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -59,7 +59,11 @@ defmodule Ace.HTTP.Service do
     quote do
       def start_link(initial_state, options \\ []) do
         # DEBT Remove this for 1.0 release
-        behaviours = __MODULE__.module_info() |> get_in([:attributes, :behaviour])
+        behaviours =
+          __MODULE__.module_info()
+          |> Keyword.get(:attributes, [])
+          |> Keyword.get_values(:behaviour)
+          |> List.flatten()
 
         if !Enum.member?(behaviours, Raxx.Server) do
           %{file: file, line: line} = __ENV__

--- a/test/ace/http/service_test.exs
+++ b/test/ace/http/service_test.exs
@@ -1,6 +1,8 @@
 defmodule Ace.HTTP.ServiceTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   @tag :skip
   test "service starts a new acceptor for each new connection" do
     {:ok, service} = Raxx.Forwarder.start_link(%{target: self()})
@@ -82,5 +84,16 @@ defmodule Ace.HTTP.ServiceTest do
     :ok = Process.sleep(100)
 
     assert Ace.HTTP.Service.count_connections(service) == 2
+  end
+
+  test "MyApp should not emit missing behaviour warnings" do
+    fun = fn ->
+      config = %{greeting: "Hello"}
+      {:ok, service} = MyApp.start_link(config, [port: 0])
+
+      GenServer.stop(service)
+    end
+
+    refute capture_io(:stderr, fun) =~ ~r"does not implement a Raxx server behaviour"
   end
 end

--- a/test/ace/http/service_test.exs
+++ b/test/ace/http/service_test.exs
@@ -89,7 +89,7 @@ defmodule Ace.HTTP.ServiceTest do
   test "MyApp should not emit missing behaviour warnings" do
     fun = fn ->
       config = %{greeting: "Hello"}
-      {:ok, service} = MyApp.start_link(config, [port: 0])
+      {:ok, service} = MyApp.start_link(config, port: 0)
 
       GenServer.stop(service)
     end

--- a/test/support.exs
+++ b/test/support.exs
@@ -95,3 +95,18 @@ defmodule Raxx.Forwarder do
     response
   end
 end
+
+defmodule MyApp do
+  @moduledoc """
+  A sample module in README
+  """
+  use Ace.HTTP.Service, [port: 8080, cleartext: true]
+  use Raxx.SimpleServer
+
+  @impl Raxx.SimpleServer
+  def handle_request(%{method: :GET, path: []}, %{greeting: greeting}) do
+    response(:ok)
+    |> set_header("content-type", "text/plain")
+    |> set_body("#{greeting}, World!")
+  end
+end

--- a/test/support.exs
+++ b/test/support.exs
@@ -100,7 +100,7 @@ defmodule MyApp do
   @moduledoc """
   A sample module in README
   """
-  use Ace.HTTP.Service, [port: 8080, cleartext: true]
+  use Ace.HTTP.Service, port: 8080, cleartext: true
   use Raxx.SimpleServer
 
   @impl Raxx.SimpleServer


### PR DESCRIPTION
As reported in https://github.com/CrowdHailer/Ace/issues/127, the current `Ace.HTTP.Service.start_link` macro mistakenly emits warning even with `use Raxx.SimpleServer`. Because the `module_info/0` function in each module can contain duplicate keys ([doc](http://erlang.org/doc/reference_manual/modules.html#module_info-0)), `Ace.HTTP.Service` should handle such a case:

```
[
  vsn: [65842577946200045591869981152062039094],
  behaviour: [Raxx.SimpleServer],
  behaviour: [Raxx.Server]
]
```