### PR TITLE
run tests on lastest stable elixir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: elixir
 elixir:
-  - 1.6.4
+  - 1.7.4
 otp_release:
-  - 19.2
-  - 20.0
+  - 20.3
+  - 21.0
 env:
   - MIX_ENV=test
 before_script:


### PR DESCRIPTION
This branch updates the test suite to run tests using elixir `1.7.4` and OTP `20` and `21`

Tests fail on OTP `20` due to changes to the accepted cypher suits in OTP `21`.
As our systems run on OTP `21` this branch will probably be updated to run on OTP `21` only. Unless an appropriate fix can be found.