### PR TITLE
Make it possible to overwrite Ace.Service default options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Current
+
+### Changed
+
+- Allow the users to specify socket options and opt out of HTTP/1.1 or HTTP2.
+
 ## [0.18.8](https://github.com/CrowdHailer/Ace/tree/0.18.8) - 2019-04-29
 
 ### Fixed

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -191,7 +191,7 @@ defmodule Ace.HTTP.Service do
       case Keyword.fetch(options, :cleartext) do
         {:ok, true} ->
           tcp_options =
-            Keyword.take(@socket_options ++ options, [
+            Keyword.take(options ++ @socket_options, [
               :mode,
               :packet,
               :active,
@@ -208,7 +208,7 @@ defmodule Ace.HTTP.Service do
 
         _ ->
           ssl_options =
-            Keyword.take(@socket_options ++ options, [
+            Keyword.take(options ++ @socket_options, [
               :mode,
               :packet,
               :active,
@@ -225,7 +225,13 @@ defmodule Ace.HTTP.Service do
           {:ok, listen_socket} = :ssl.listen(port, ssl_options)
           listen_socket = {:ssl, listen_socket}
           {:ok, port} = Ace.Socket.port(listen_socket)
-          Logger.info("Serving securely using HTTP/1 and HTTP/2 on port #{port}")
+
+          Logger.info(
+            "Serving securely using #{
+              inspect(Keyword.get(ssl_options, :alpn_preferred_protocols))
+            } on port #{port}"
+          )
+
           listen_socket
       end
 

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -126,6 +126,13 @@ defmodule Ace.HTTP.Service do
 
     * `:acceptors` - The number of servers simultaneously waiting for a connection.
       Defaults to 100.
+
+  Internal socket options can also be specified, most notably:
+
+    * `:alpn_preferred_protocols` - which protocols should be negotiated for the
+      https traffic. Defaults to `["h2", "http/1.1"]`
+
+  The additional options will be passed to `:gen_tcp.listen/2` and `:ssl.listen/2` as appropriate.
   """
   @spec start_link({module, any}, [{atom, any}]) :: {:ok, service}
   def start_link(app = {module, _config}, options) do


### PR DESCRIPTION
I was having some problems with Ace's HTTP2 behaviour and in the meantime wanted to stick with HTTP1 over ssl (happy to talk about the HTTP2 problem independently).

I realized it's currently not possible to overwrite the default `Ace.Service` options.

The way I use it in my app, with this change is:

```
    secure_options = [
      port: secure_port(),
      certfile: certificate_path(),
      keyfile: certificate_key_path(),
      alpn_preferred_protocols: ["http/1.1"] # this is now possible
    ]

    children = [
      {FileBeam.WWW, [cleartext_options]},
      {FileBeam.WWW, [secure_options]},
      Supervisor.child_spec({Registry, [keys: :unique, name: BufferRegistry]}, []),
      {DynamicSupervisor, strategy: :one_for_one, name: BufferSupervisor}
    ]

```

I'm not suggesting this be the final implementation, just showing something that solves my problem.