### PR TITLE
Use IO.warn over no-longer-existing :elixir_errors.warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow the users to specify socket options and opt out of HTTP/1.1 or HTTP2.
 
+### Fixed
+
+- Fix dialyzer warning about `:elixir_errors.warn` on Elixir >= 1.9.0
+
 ## [0.18.8](https://github.com/CrowdHailer/Ace/tree/0.18.8) - 2019-04-29
 
 ### Fixed

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -66,13 +66,14 @@ defmodule Ace.HTTP.Service do
           |> List.flatten()
 
         if !Enum.member?(behaviours, Raxx.Server) do
-          %{file: file, line: line} = __ENV__
-
-          :elixir_errors.warn(__ENV__.line, __ENV__.file, """
-          The service `#{inspect(__MODULE__)}` does not implement a Raxx server behaviour
-              This module should either `use Raxx.Server` or `use Raxx.SimpleServer.`
-              The behaviour Ace.HTTP.Service changed in release 0.18.0, see CHANGELOG for details.
-          """)
+          IO.warn(
+            """
+            The service `#{inspect(__MODULE__)}` does not implement a Raxx server behaviour
+                This module should either `use Raxx.Server` or `use Raxx.SimpleServer.`
+                The behaviour Ace.HTTP.Service changed in release 0.18.0, see CHANGELOG for details.
+            """,
+            Macro.Env.stacktrace(__ENV__)
+          )
         end
 
         application = {__MODULE__, initial_state}


### PR DESCRIPTION
Closes #137 

Replace usage of `:elixir_errors.warn/3` with `IO.warn/2`, since the former no longer exists in Elixir 1.9.0.

Not sure how to test this other than running a server that would give this warning, so I did:
![image](https://user-images.githubusercontent.com/728042/64893313-04b60200-d677-11e9-99d9-1f3eb77ea267.png)
