### PR TITLE
Add and fix some type specs

### DIFF
--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -137,7 +137,7 @@ defmodule Ace.HTTP.Service do
 
   The additional options will be passed to `:gen_tcp.listen/2` and `:ssl.listen/2` as appropriate.
   """
-  @spec start_link({module, any}, [{atom, any}]) :: {:ok, service} | {:error, term}
+  @spec start_link({module, any}, [{atom, any}]) :: GenServer.on_start()
   def start_link(app = {module, _config}, options) do
     Raxx.Server.verify_implementation!(module)
 

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -57,6 +57,8 @@ defmodule Ace.HTTP.Service do
     {defaults, []} = Module.eval_quoted(__CALLER__, defaults)
 
     quote do
+      @spec start_link(any, [{atom, any}]) ::
+              {:ok, unquote(__MODULE__).service()} | {:error, term}
       def start_link(initial_state, options \\ []) do
         # DEBT Remove this for 1.0 release
         behaviours =

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -51,7 +51,7 @@ defmodule Ace.HTTP.Service do
 
   This process should be added to a supervision tree as a supervisor.
   """
-  @type service :: pid
+  @type service :: GenServer.server()
 
   defmacro __using__(defaults) do
     {defaults, []} = Module.eval_quoted(__CALLER__, defaults)
@@ -135,7 +135,7 @@ defmodule Ace.HTTP.Service do
 
   The additional options will be passed to `:gen_tcp.listen/2` and `:ssl.listen/2` as appropriate.
   """
-  @spec start_link({module, any}, [{atom, any}]) :: {:ok, service}
+  @spec start_link({module, any}, [{atom, any}]) :: {:ok, service} | {:error, term}
   def start_link(app = {module, _config}, options) do
     Raxx.Server.verify_implementation!(module)
 

--- a/lib/ace/http2/settings.ex
+++ b/lib/ace/http2/settings.ex
@@ -16,10 +16,29 @@ defmodule Ace.HTTP2.Settings do
   @initial_window_size_minimum 0
   @initial_window_size_maximum 2_147_483_647
 
+  @type t :: %__MODULE__{}
+
+  @type option ::
+          {:max_frame_size, integer}
+          | {:initial_window_size, integer}
+          | {:max_concurrent_streams, integer}
+          | {:enable_push, boolean}
+
+  @type options :: [option]
+
+  @type on_init ::
+          {:ok, t}
+          | {:error, :max_frame_size_too_small}
+          | {:error, :max_frame_size_too_large}
+          | {:error, :initial_window_size_too_small}
+          | {:error, :initial_window_size_too_large}
+
+  @spec for_server(options) :: on_init
   def for_server(values \\ []) do
     for_client([{:enable_push, false} | values])
   end
 
+  @spec for_client(options) :: on_init
   def for_client(values \\ []) do
     case Keyword.get(values, :max_frame_size, @max_frame_size_default) do
       value when value < @max_frame_size_default ->


### PR DESCRIPTION
Because the Dialyzer had emitted some errors when compiling with this library, so I added/fixed some type specs.

- Changed `Ace.HTTP.Service.service` to `GenServer.server` - `GenServer.call/2` can take several type of argument other than `pid`.
- `Ace.HTTP.Service.start_link/2` actually invoke `GenServer.start_link/3`, so changed the return type of the function to `GenServer.on_start` which allows `{:error, term}` too.
- Add type specs `Ace.HTTP2.Settings`.

