### PR TITLE
Custom max_line_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a web project based on [Raxx](https://github.com/CrowdHailer/raxx)/[Ace](https:/
 #### Hello, World!
 ```elixir
 defmodule MyApp do
-  use Ace.HTTP.Service, port: 8080, cleartext: true
+  use Ace.HTTP.Service, port: 8080, cleartext: true, max_line_length: 4096
   use Raxx.SimpleServer
 
   @impl Raxx.SimpleServer

--- a/lib/ace/http/server.ex
+++ b/lib/ace/http/server.ex
@@ -76,7 +76,7 @@ defmodule Ace.HTTP.Server do
               worker: worker,
               monitor: monitor,
               keep_alive: false,
-              receive_state: Ace.HTTP1.Parser.new(max_line_length: 2048),
+              receive_state: Ace.HTTP1.Parser.new(state.settings),
               pending_ack_count: 0,
               error_response: Keyword.get(state.settings, :error_response)
             }

--- a/lib/ace/http/service.ex
+++ b/lib/ace/http/service.ex
@@ -131,6 +131,8 @@ defmodule Ace.HTTP.Service do
     * `:error_response` - The response that Ace will send if a request handler crashes.
       Useful for setting custom headers, e.g. for CORS.
 
+    * `:max_line_length` - The maximum line length a request header can have.
+
   Internal socket options can also be specified, most notably:
 
     * `:alpn_preferred_protocols` - which protocols should be negotiated for the

--- a/lib/ace/http1/parser.ex
+++ b/lib/ace/http1/parser.ex
@@ -32,7 +32,7 @@ defmodule Ace.HTTP1.Parser do
   """
   @spec new([option]) :: state
   def new(opts) do
-    max_line_length = Keyword.get(opts, :max_line_length)
+    max_line_length = Keyword.get(opts, :max_line_length, 2048)
     {:start_line, "", %{max_line_length: max_line_length}}
   end
 


### PR DESCRIPTION
Adds the option to pass max_line_length argument to Ace.HTTP.Service keeping the default as 2048 bytes.

Also updates README and docs.